### PR TITLE
Restrict base bounds

### DIFF
--- a/serialize-instances.cabal
+++ b/serialize-instances.cabal
@@ -60,7 +60,7 @@ library
   default-extensions:    TemplateHaskell, QuasiQuotes, DefaultSignatures, MultiParamTypeClasses, RankNTypes, FlexibleInstances, FlexibleContexts
   
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.7 && <5, semigroups >=0.16 && <0.19, cereal >=0.4 && <0.6, unordered-containers, hashable
+  build-depends:       base >=4.8 && <4.10, semigroups >=0.16 && <0.19, cereal >=0.4 && <0.6, unordered-containers, hashable
   
   ghc-options: -W -fwarn-missing-signatures 
          -fwarn-incomplete-uni-patterns


### PR DESCRIPTION
I made a revision already https://hackage.haskell.org/package/serialize-instances-0.1.0.0/revisions/, so no immediate action after merging is required. This PR is to make sure that new versions won't regress.

The package failed to compile with newer base:

```
Data/Serialize/Instances.hs:9:1: error:
    Could not find module ‘Data.Typeable.Internal’
    it is a hidden module in the package ‘base-4.10.1.0’
    Use -v to see a list of the files searched for.
  |
9 | import Data.Typeable.Internal
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

as well as with older

```
Data/Serialize/Instances.hs:26:20: Not in scope: ‘<$>’

Data/Serialize/Instances.hs:26:28: Not in scope: ‘<*>’

Data/Serialize/Instances.hs:26:36: Not in scope: ‘<*>’

Data/Serialize/Instances.hs:38:25: Not in scope: ‘<$>’
```